### PR TITLE
Remove Amazon Smile redirect

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -40,9 +40,7 @@ function redirector(details) {
 
   if (parsedUrl.host.indexOf('reddit.com') >= '0') {
     return { redirectUrl: `https://${siteVersion === 'new' ? 'www' : 'old'}.reddit.com/hot` };
-  } else if (parsedUrl.host.indexOf('amazon.com') >= 0) {
-    return { redirectUrl: `https://smile.amazon.com/` };
   }
 }
 
-chrome.webRequest.onBeforeRequest.addListener(redirector, { urls: ['*://*.reddit.com/*', '*://*.amazon.com/*'] }, ["blocking"]);
+chrome.webRequest.onBeforeRequest.addListener(redirector, { urls: ['*://*.reddit.com/*'] }, ["blocking"]);


### PR DESCRIPTION
This extension is for redirecting Reddit requests - you should not be opinionated on anything but Reddit.  Not to mention this also breaks the AWS console (https://console.aws.amazon.com/) and Amazon Prime Now (https://primenow.amazon.com), and access to anything for Amazon employees, such as webmail.

Extensions exist to do the Smile redirect that do not break those things - you should let those extensions handle Amazon Smile redirects and leave yours to handle Reddit.